### PR TITLE
Update test-and-release.yml - add windows tests

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Github testing should be performed at all supported platforms  (linux, windows, macos). Windows test are currently missing at your workflow but work without any problems.

So please check / merge this PR or add windows to the list of tested platforms manually if you prefer.

Thanks.